### PR TITLE
Error instead of abort on invalid seek head entry

### DIFF
--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -164,6 +164,11 @@ pub enum MatroskaError {
     InvalidFloat,
     /// An invalid date value
     InvalidDate,
+    /// Invalid seek head entry
+    InvalidSeekHead {
+        /// The invalid id
+        id: u32,
+    },
 }
 
 impl From<std::io::Error> for MatroskaError {
@@ -183,6 +188,7 @@ impl fmt::Display for MatroskaError {
             MatroskaError::InvalidUint => write!(f, "invalid unsigned integer"),
             MatroskaError::InvalidFloat => write!(f, "invalid float"),
             MatroskaError::InvalidDate => write!(f, "invalid date"),
+            MatroskaError::InvalidSeekHead { id } => write!(f, "invalid seek head id={}", id),
         }
     }
 }


### PR DESCRIPTION
# Background
When recording webm-files from a live stream the `gstreamer` tool will first write an invalid placeholder seek head with -1 for the positions. 
When later stopping the recording `gstreamer` will fill in the correct offsets in seek head .
But if the recording program is killed and the stop is unclean the file will still contain the invalid seek head.
Currently the `matroska`-crate will panic on `u64` overflow in this scenario.
An integer overflow panic aborts the process and cannot even by catched with  `catch_unwind`.

# What is changed by this PR
This PR ensures there is an Error instead of panic when the seek head contains an invalid offset such as (-1).