### PR TITLE
fix panic on invalid size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -127,7 +127,9 @@ impl Element {
         let mut elements = Vec::new();
         while size > 0 {
             let e = Element::parse(r)?;
-            assert!(e.size <= size);
+            if e.size > size {
+                return Err(MatroskaError::InvalidSize);
+            }
             size -= e.size;
             elements.push(e);
         }


### PR DESCRIPTION
Hello,

Thank you for your work on this crate !

This pull request adds a basic `.gitignore` for regular rust stuffs and fix a panic when the size of an element overlaps the size of its master element.

Cheers.